### PR TITLE
Update plugin icon to custom.typingmind.com asset

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "uuid": "70606b50-137b-45c3-8688-545398dc85a0",
   "id": "search_via_perplexity",
-  "iconURL": "https://custom.typingmind.com/assets/models/perplexityai.png",
+  "iconURL": "https://custom.typingmind.com/assets/plugins/perplexity.webp",
   "emoji": "🔍",
   "title": "Perplexity Search",
   "userSettings": [


### PR DESCRIPTION
Points the plugin icon to the shared brand asset (reused across plugins for this brand):

```
https://custom.typingmind.com/assets/plugins/perplexity.webp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)